### PR TITLE
Update mode.cpp

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -59,6 +59,7 @@ bool Mode::enter()
     plane.guided_state.target_heading_type = GUIDED_HEADING_NONE;
     plane.guided_state.target_airspeed_cm = -1; // same as above, although an airspeed of -1 is rare on plane.
     plane.guided_state.target_alt = -1; // same as above, although a target alt of -1 is rare on plane.
+    plane.guided_state.target_alt_time_ms = 0;
     plane.guided_state.last_target_alt = 0;
 #endif
 


### PR DESCRIPTION
1. [guided_state](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/Plane.h#L521-L552)
    1. [initialization](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/Plane.h#L537) - target_alt is set to -1 and target_alt_time_ms is set to 0


2. [MAV_CMD_GUIDED_CHANGE_ALTITUDE](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/GCS_Mavlink.cpp#L850)
    1. sets [plane.guided_state.target_alt_time_ms](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/GCS_Mavlink.cpp#L890) as well as target_alt
3. [ModeGuided::update_target_altitude](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode_guided.cpp#L126)
    1. if OFG and (target_alt_time_ms or target_alt are not default) use target_alt for [plane.set_target_altitude_location](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode_guided.cpp#L146)
4. [Mode::enter](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode.cpp#L26C6-L26C17)
    1. [resets](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode.cpp#L53-L62) plane.guided_state.target_alt, but not target_alt_time_ms - this is a 🐛 or triggers the bug!
5. [ModeGuided::update_target_altitude](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode_guided.cpp#L126)
    1. if OFG and (target_alt_time_ms or target_alt are not default) use target_alt (which got set to -1 in Mode::enter) for [plane.set_target_altitude_location](https://github.com/ArduPilot/ardupilot/blob/c99b5e5d47d3d891f0d77a2bf026c5bae588e06c/ArduPlane/mode_guided.cpp#L146)